### PR TITLE
Fix SPSC and MPSC async benchmarks

### DIFF
--- a/z_async_all.rs
+++ b/z_async_all.rs
@@ -41,38 +41,47 @@ async fn mpsc<T: BenchType + 'static>(cap: Option<usize>) {
         list.push(h);
     }
 
-    for _ in 0..MESSAGES {
-        rx.recv().await.unwrap().test()
-    }
+    list.push(tokio::spawn(async move {
+        for _ in 0..MESSAGES {
+            rx.recv().await.unwrap().test()
+        }
+    }));
+
     for h in list {
         h.await.unwrap();
     }
 }
 
-async fn seq<T: BenchType>(cap: Option<usize>) {
-    let (tx, rx) = new(cap);
-
-    for i in 1..MESSAGES+1 {
-        tx.send(T::new(i)).await.unwrap();
-    }
-
-    for _ in 0..MESSAGES {
-        rx.recv().await.unwrap().test()
-    }
-}
-
-async fn spsc<T: BenchType + 'static>(cap: Option<usize>) {
+async fn seq<T: BenchType + 'static>(cap: Option<usize>) {
     let (tx, rx) = new(cap);
 
     let h = tokio::spawn(async move {
         for i in 1..MESSAGES+1 {
             tx.send(T::new(i)).await.unwrap();
         }
+
+        for _ in 0..MESSAGES {
+            rx.recv().await.unwrap().test()
+        }
     });
 
-    for _ in 0..MESSAGES {
-        rx.recv().await.unwrap().test()
-    }
-
     h.await.unwrap();
+}
+
+async fn spsc<T: BenchType + 'static>(cap: Option<usize>) {
+    let (tx, rx) = new(cap);
+
+    let htx = tokio::spawn(async move {
+        for i in 1..MESSAGES+1 {
+            tx.send(T::new(i)).await.unwrap();
+        }
+    });
+    let hrx = tokio::spawn(async move {
+        for _ in 0..MESSAGES {
+            rx.recv().await.unwrap().test()
+        }
+    });
+
+    htx.await.unwrap();
+    hrx.await.unwrap();
 }


### PR DESCRIPTION
This PR fixes an important issue in the SPSC and MPSC benchmarks.

The problem is that in these benchmarks, the receiver runs directly inside `main` instead of being spawned. With the `#[tokio::main]` macro, in practice this means that Tokio will run the receiver inside a `block_on()` call. This completely kills performance because `block_on` is just a thread-based primitive.

The `async` performance of all channels is vastly improved after this fix, and their relative speed is affected.

One problem though: for me `kanal-async` hangs 99% of the time in these benchmarks so I could not actually test the PR on `kanal` itself. I observed the same problem on [Tachyobench](https://github.com/asynchronics/tachyobench/) (see my reddit [comment](https://www.reddit.com/r/rust/comments/y5im3n/comment/isnch12/?utm_source=share&utm_medium=web2x&context=3)). I will open a separate issue for that on the `kanal` repo.